### PR TITLE
Include latency metrics in stats sent to datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ The following metrics are collected from Artillery and sent to Datadog.
 - **artillery.response.5xx**: Aggregate count of all responses whose HTTP code was in the `5xx` range
 - **artillery.response.200**: Count of responses whose HTTP code was `200` (exactly). Similarly named metric is repeated for each response status code
 - **artillery.response.ok_pct**: Percentage (in the range `0 - 100`) of responses that returned with a `2xx` or `3xx` status code
+- **artillery.latency.min**: Min latency
+- **artillery.latency.max**: Max latency
+- **artillery.latency.p99**: 99th percentile latency
+- **artillery.latency.p95**: 95th percentile latency
+- **artillery.latency.median**: Median latency
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-plugin-datadog",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Datadog output plugin for Artillery",
   "main": "src/index.js",
   "keywords": [

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -59,6 +59,9 @@ class DatadogPlugin
       metrics["response.#{code[0]}xx"] += count
       metrics["response.#{code}"] = count
 
+    for type,value of stats.latency
+      metrics["latency.#{type}"]=value
+
     metrics['response.ok_pct'] = @getOkPercentage metrics
 
     tags = @getTags()


### PR DESCRIPTION
Seeing latency metrics in datadog is very useful. They can be used (among other things) to setup automated alarms on performance regressions. 